### PR TITLE
feat: Implement Domain Layer for Manga Feature with Pagination

### DIFF
--- a/lib/features/manga/domain/entities/manga_entity.dart
+++ b/lib/features/manga/domain/entities/manga_entity.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+
+class MangaEntity extends Equatable {
+  final String id;
+  final String title;
+  final String imageUrl;
+  final String coverImageUrl;
+  final String description;
+  final num ranking;
+  final String rating;
+  final String type;
+  final String status;
+  final num episodesCount;
+  final String createdAt;
+  final num episodeLength;
+
+  const MangaEntity(
+      {required this.id,
+      required this.title,
+      required this.coverImageUrl,
+      required this.imageUrl,
+      required this.description,
+      required this.ranking,
+      required this.rating,
+      required this.type,
+      required this.status,
+      required this.episodesCount,
+      required this.createdAt,
+      required this.episodeLength});
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        imageUrl,
+        description,
+        ranking,
+        rating,
+        type,
+        status,
+        episodesCount,
+        createdAt,
+        episodeLength,
+        coverImageUrl
+      ];
+}

--- a/lib/features/manga/domain/repository/manga_repository.dart
+++ b/lib/features/manga/domain/repository/manga_repository.dart
@@ -1,0 +1,13 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/manga/domain/entities/manga_entity.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class MangaRepository {
+  Future<Either<Failure, List<MangaEntity>>> getTopRatedManga({int page = 1});
+
+  Future<Either<Failure, List<MangaEntity>>> getPopularManga({int page = 1});
+
+  Future<Either<Failure, List<MangaEntity>>> getLatestManga();
+
+  Future<Either<Failure, MangaEntity>> getMangaDetails(int id);
+}

--- a/lib/features/manga/domain/usecases/get_latest_manga_usecase.dart
+++ b/lib/features/manga/domain/usecases/get_latest_manga_usecase.dart
@@ -1,0 +1,14 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/manga/domain/entities/manga_entity.dart';
+import 'package:anime_app/features/manga/domain/repository/manga_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetLatestMangaUsecase {
+  final MangaRepository mangaRepository;
+
+  GetLatestMangaUsecase({required this.mangaRepository});
+
+  Future<Either<Failure, List<MangaEntity>>> call() async {
+    return await mangaRepository.getLatestManga();
+  }
+}

--- a/lib/features/manga/domain/usecases/get_manga_details_usecase.dart
+++ b/lib/features/manga/domain/usecases/get_manga_details_usecase.dart
@@ -1,0 +1,14 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/manga/domain/entities/manga_entity.dart';
+import 'package:anime_app/features/manga/domain/repository/manga_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetMangaDetailsUsecase {
+  final MangaRepository mangaRepository;
+
+  GetMangaDetailsUsecase({required this.mangaRepository});
+
+  Future<Either<Failure, MangaEntity>> call(int id) async {
+    return await mangaRepository.getMangaDetails(id);
+  }
+}

--- a/lib/features/manga/domain/usecases/get_popular_manga_usecase.dart
+++ b/lib/features/manga/domain/usecases/get_popular_manga_usecase.dart
@@ -1,0 +1,14 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/manga/domain/entities/manga_entity.dart';
+import 'package:anime_app/features/manga/domain/repository/manga_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetPopularMangaUsecase {
+  final MangaRepository mangaRepository;
+
+  GetPopularMangaUsecase({required this.mangaRepository});
+
+  Future<Either<Failure, List<MangaEntity>>> call({int page = 1}) async {
+    return await mangaRepository.getPopularManga(page: page);
+  }
+}

--- a/lib/features/manga/domain/usecases/get_top_rated_manga_usecase.dart
+++ b/lib/features/manga/domain/usecases/get_top_rated_manga_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/manga/domain/entities/manga_entity.dart';
+import 'package:anime_app/features/manga/domain/repository/manga_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetTopRatedMangaUsecase {
+  final MangaRepository mangaRepository;
+
+  GetTopRatedMangaUsecase({
+    required this.mangaRepository,
+  });
+
+  Future<Either<Failure, List<MangaEntity>>> call({int page = 1}) async {
+    return await mangaRepository.getTopRatedManga(page: page);
+  }
+}


### PR DESCRIPTION
### Description
This PR implements the domain layer for the manga feature, including the following components:
- `MangaEntity`
- `MangaRepository`
- `GetLatestMangaUsecase`
- `GetMangaDetailsUsecase`
- `GetPopularMangaUsecase` (with pagination)
- `GetTopRatedMangaUsecase` (with pagination)

### Changes
- Added `MangaEntity` to represent the manga domain model
- Created `MangaRepository` interface
- Implemented `GetLatestMangaUsecase` for retrieving the latest manga
- Implemented `GetMangaDetailsUsecase` for retrieving manga details
- Implemented `GetPopularMangaUsecase` with pagination
- Implemented `GetTopRatedMangaUsecase` with pagination

### Testing
Tested the new use cases to ensure they work correctly, including pagination functionality for popular and top-rated manga.
