### PR TITLE
Refactor Character Entity and Add Character Use Cases

### DIFF
--- a/lib/features/characters/domain/entities/character_entity.dart
+++ b/lib/features/characters/domain/entities/character_entity.dart
@@ -2,28 +2,22 @@ import 'package:equatable/equatable.dart';
 
 class CharacterEntity extends Equatable {
   final String id;
-  final String title;
   final String description;
   final String imageUrl;
   final String name;
-  final String role;
 
   const CharacterEntity({
     required this.id,
-    required this.title,
     required this.description,
     required this.imageUrl,
     required this.name,
-    required this.role,
   });
 
   @override
   List<Object> get props => [
         id,
-        title,
         description,
         imageUrl,
         name,
-        role,
       ];
 }

--- a/lib/features/characters/domain/repository/character_repository.dart
+++ b/lib/features/characters/domain/repository/character_repository.dart
@@ -3,6 +3,9 @@ import 'package:anime_app/features/characters/domain/entities/character_entity.d
 import 'package:dartz/dartz.dart';
 
 abstract class CharacterRepository {
-  Future<Either<Failure, List<CharacterEntity>>> getCharacters(
-      {required int page});
+  Future<Either<Failure, List<CharacterEntity>>> getCharactersList(
+      {required int animeId, required int page});
+
+  Future<Either<Failure, CharacterEntity>> getCharacter({required int id});
 }
+

--- a/lib/features/characters/domain/usecases/get_characters_list_usecase.dart
+++ b/lib/features/characters/domain/usecases/get_characters_list_usecase.dart
@@ -10,7 +10,9 @@ class GetCharactersListUsecase {
     required this.characterRepository,
   });
 
-  Future<Either<Failure, CharacterEntity>> call({required int id}) async {
-    return await characterRepository.getCharacter(id: id);
+  Future<Either<Failure, List<CharacterEntity>>> call(
+      {required int animeId, int page = 1}) async {
+    return await characterRepository.getCharactersList(
+        animeId: animeId, page: page);
   }
 }


### PR DESCRIPTION
- Removed `title` and `role` properties from `character_entity`.
- Implemented `get_characters_list_usecase` which retrieves a list of characters for a given anime ID and page.
- Implemented `get_character_usecase` which retrieves character details based on character ID.
- Updated `character_repository` to include methods for:
  - `Future<Either<Failure, List<CharacterEntity>>> getCharactersList({required int animeId, required int page})`
- Enhanced the domain layer with these new use cases to facilitate character data handling.
