### PR TITLE
Add Episode Domain Layer Implementation

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -21,3 +21,6 @@ const categoryByAnimeId = "https://kitsu.io/api/edge/anime/";
 const afterCategoryAnimeId =
     "/categories?page%5Blimit%5D=20&page%5Boffset%5D=0";
 const categoryById = "https://kitsu.io/api/edge/categories/";
+const episodeByAnimeId = "https://kitsu.io/api/edge/anime/";
+const afterEpisodeByAnimeId = "/episodes?page%5Blimit%5D=10&page%5Boffset%5D=0";
+const episodeById = "https://kitsu.io/api/edge/episodes/";

--- a/lib/features/episode/domain/entities/episode_entity.dart
+++ b/lib/features/episode/domain/entities/episode_entity.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+
+class EpisodeEntity extends Equatable {
+  final int id;
+  final String title;
+  final String description;
+  final String image;
+  final int seasonNumber;
+  final int episodeNumber;
+  final int length;
+
+  const EpisodeEntity({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.image,
+    required this.seasonNumber,
+    required this.episodeNumber,
+    required this.length,
+  });
+
+  @override
+  List<Object> get props => [
+        id,
+        title,
+        description,
+        image,
+        seasonNumber,
+        episodeNumber,
+        length,
+      ];
+}

--- a/lib/features/episode/domain/repository/episode_repository.dart
+++ b/lib/features/episode/domain/repository/episode_repository.dart
@@ -1,0 +1,10 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/episode/domain/entities/episode_entity.dart';
+import 'package:dartz/dartz.dart';
+
+abstract class EpisodeRepository {
+  Future<Either<Failure, List<EpisodeEntity>>> getEpisodesList(
+      {required String animeId, int page});
+
+  Future<Either<Failure, EpisodeEntity>> getEpisodeById({required String id});
+}

--- a/lib/features/episode/domain/usecases/get_episode_by_id_usecase.dart
+++ b/lib/features/episode/domain/usecases/get_episode_by_id_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/episode/domain/entities/episode_entity.dart';
+import 'package:anime_app/features/episode/domain/repository/episode_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetEpisodeByIdUsecase {
+  final EpisodeRepository episodeRepository;
+
+  GetEpisodeByIdUsecase({
+    required this.episodeRepository,
+  });
+
+  Future<Either<Failure, EpisodeEntity>> call({required String id}) async {
+    return await episodeRepository.getEpisodeById(id: id);
+  }
+}

--- a/lib/features/episode/domain/usecases/get_episodes_list_usecase.dart
+++ b/lib/features/episode/domain/usecases/get_episodes_list_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:anime_app/core/error/failure.dart';
+import 'package:anime_app/features/episode/domain/entities/episode_entity.dart';
+import 'package:anime_app/features/episode/domain/repository/episode_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class GetEpisodesListUsecase {
+  final EpisodeRepository episodeRepository;
+
+  GetEpisodesListUsecase({
+    required this.episodeRepository,
+  });
+
+  Future<Either<Failure, List<EpisodeEntity>>> call(
+      {required String animeId, int page = 1}) async {
+    return await episodeRepository.getEpisodesList(
+        animeId: animeId, page: page);
+  }
+}


### PR DESCRIPTION
### Description
This PR adds the domain layer implementation for the Episode feature, including entities, repository interface, and use cases.

### Changes

#### Domain Layer
- Added `episode_entity.dart`
- Added `episode_repository.dart`
- Added `get_episode_by_id_usecase.dart`
- Added `get_episodes_list_usecase.dart`
