### PR TITLE
Add Anime Details UI Components

### DIFF
--- a/lib/core/widgets/anime_card.dart
+++ b/lib/core/widgets/anime_card.dart
@@ -2,6 +2,7 @@ import 'package:anime_app/core/constants/app_colors.dart';
 import 'package:anime_app/core/constants/app_text_styles.dart';
 import 'package:anime_app/core/widgets/rating_card.dart';
 import 'package:anime_app/features/anime/domain/entities/anime_entity.dart';
+import 'package:anime_app/features/anime/presentation/views/anime_details.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
@@ -10,54 +11,60 @@ class AnimeCard extends StatelessWidget {
   final AnimeEntity anime;
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: ShapeDecoration(
-        color: AppColors.grey800.withOpacity(0.8),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(MaterialPageRoute(
+            builder: (context) => AnimeDetails(anime: anime)));
+      },
+      child: Container(
+        decoration: ShapeDecoration(
+          color: AppColors.grey800.withOpacity(0.8),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
         ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              flex: 5,
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: CachedNetworkImage(
-                        imageUrl: anime.imageUrl,
-                        fit: BoxFit.cover,
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                flex: 5,
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: CachedNetworkImage(
+                          imageUrl: anime.imageUrl,
+                          fit: BoxFit.cover,
+                        ),
                       ),
                     ),
-                  ),
-                  Positioned(
-                    left: 4,
-                    top: 8,
-                    child: RatingCard(
-                      rating: anime.rating,
+                    Positioned(
+                      left: 4,
+                      top: 8,
+                      child: RatingCard(
+                        rating: anime.rating,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Expanded(
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  anime.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyles.link.copyWith(color: AppColors.grey50),
+                  ],
                 ),
               ),
-            ),
-          ],
+              const SizedBox(height: 8),
+              Expanded(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    anime.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.link.copyWith(color: AppColors.grey50),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/core/widgets/anime_cover_container.dart
+++ b/lib/core/widgets/anime_cover_container.dart
@@ -1,0 +1,33 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class AnimeCoverContainer extends StatelessWidget {
+  const AnimeCoverContainer({super.key, required this.coverImageUrl});
+  final String coverImageUrl;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 1200,
+          height: 480,
+          decoration: ShapeDecoration(
+            image: DecorationImage(
+              image: CachedNetworkImageProvider(coverImageUrl),
+              onError: (_, __) => const Icon(Icons.error),
+              fit: BoxFit.cover,
+            ),
+            gradient: const LinearGradient(
+              begin: Alignment(0.00, -1.00),
+              end: Alignment(0, 1),
+              colors: [Color(0xFF362C92), Color(0xFF116197)],
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(40),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/widgets/anime_title_container.dart
+++ b/lib/core/widgets/anime_title_container.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class AnimeTitleContainer extends StatelessWidget {
+  const AnimeTitleContainer({super.key, required this.animeTitle});
+  final String animeTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 500,
+          height: 120,
+          padding: const EdgeInsets.all(40),
+          decoration: ShapeDecoration(
+            color: const Color(0xCC20283E),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(24),
+            ),
+          ),
+          child: Center(
+            child: Text(
+              animeTitle,
+              style: const TextStyle(
+                color: Color(0xFFEBEEF5),
+                fontSize: 32,
+                fontFamily: 'Poppins',
+                fontWeight: FontWeight.w600,
+                height: 0.04,
+                letterSpacing: -0.64,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/anime/data/models/anime_model.dart
+++ b/lib/features/anime/data/models/anime_model.dart
@@ -22,8 +22,8 @@ class AnimeModel extends AnimeEntity {
     return AnimeModel(
       id: json['id'] ?? '',
       title: attributes['titles']?['en'] ?? 'Unknown Title',
-      imageUrl: attributes['posterImage']?['tiny'] ?? '',
-      coverImageUrl: attributes['coverImage']?['tiny'] ?? '',
+      imageUrl: attributes['posterImage']?['original'] ?? '',
+      coverImageUrl: attributes['coverImage']?['original'] ?? '',
       description: attributes['description'] ?? 'No description available',
       rating: attributes['averageRating'] ?? '0.0',
       status: attributes['status'] ?? 'Unknown',

--- a/lib/features/anime/presentation/views/anime_details.dart
+++ b/lib/features/anime/presentation/views/anime_details.dart
@@ -1,0 +1,40 @@
+import 'package:anime_app/core/widgets/anime_cover_container.dart';
+import 'package:anime_app/core/widgets/anime_title_container.dart';
+import 'package:anime_app/core/widgets/app_app_bar.dart';
+import 'package:anime_app/features/anime/domain/entities/anime_entity.dart';
+import 'package:flutter/material.dart';
+
+class AnimeDetails extends StatelessWidget {
+  const AnimeDetails({super.key, required this.anime});
+  final AnimeEntity anime;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const AppAppBar(),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(120),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  AnimeCoverContainer(
+                    coverImageUrl: anime.coverImageUrl,
+                  ),
+                  Positioned(
+                    top: 400,
+                    left: 120,
+                    child: AnimeTitleContainer(
+                      animeTitle: anime.title,
+                    ),
+                  ),
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:anime_app/anime_app.dart';
 import 'package:anime_app/core/dependency_injection/service_locator.dart';
+import 'package:anime_app/features/anime/presentation/views/anime_details.dart';
 import 'package:flutter/material.dart';
 
 void main() async {


### PR DESCRIPTION

  - **Overview:** Added `AnimeTitleContainer`, `AnimeCoverContainer`, and the initial implementation of the `AnimeDetails` screen. This includes the basic layout for displaying an anime's cover image and title. The `AnimeDetails` screen structure is set up but not fully completed.
  - **Components Added:**
    - `AnimeTitleContainer`: Displays the anime's title with a custom style and layout.
    - `AnimeCoverContainer`: Shows the anime's cover image with a gradient overlay.
    - `AnimeDetails`: The screen for displaying detailed information about an anime, currently in progress.
  - **Next Steps:** Complete the `AnimeDetails` screen by adding more content and interactions.
